### PR TITLE
Update history definiton

### DIFF
--- a/src/main/java/zone/nora/coronavirus/data/locations/Location.java
+++ b/src/main/java/zone/nora/coronavirus/data/locations/Location.java
@@ -48,7 +48,7 @@ public class Location {
     private String countryCode;
 
     @SerializedName("history")
-    private HashMap<String, String> history;
+    private HashMap<String, Integer> history;
 
     @SerializedName("latest")
     private int latest;
@@ -68,7 +68,7 @@ public class Location {
         return countryCode;
     }
 
-    public HashMap<String, String> getHistory() {
+    public HashMap<String, Integer> getHistory() {
         return history;
     }
 


### PR DESCRIPTION
Thanks for making this API wrapper! Per https://github.com/ExpDev07/coronavirus-tracker-api/commit/002e1afa18a74486227f87ddfd2674fdbf87db23, history now returns a string-integer pair instead of string-string (which was really a bug). This should make sure the wrapper is up per the history definition.